### PR TITLE
Coroutine-based native predicates & Go 1.23 iterators

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,35 +1,35 @@
-  name: Test
+name: Test
 
-  on:
-    push:
-      tags:
-        - "v*"
-      branches:
-        - "*"
-    pull_request:
-    release:
-      types: [created]
+on:
+  push:
+    tags:
+      - "v*"
+    branches:
+      - "*"
+  pull_request:
+  release:
+    types: [created]
 
-  jobs:
-    test:
-      name: Build & Test
-      runs-on: ${{ matrix.os }}
-      strategy:
-        fail-fast: false
-        matrix:
-          os:
-            - ubuntu-latest
-            - macos-latest
-            - windows-latest
-      steps:
-        - uses: actions/checkout@v3
-        - name: Install Go
-          uses: actions/setup-go@v3
-          with:
-            go-version: "1.21"
-        - name: Deps
-          run: go get ./trealla
-        - name: Build
-          run: go build ./trealla
-        - name: Test
-          run: go test -v ./trealla --short
+jobs:
+  test:
+    name: Build & Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.23"
+      - name: Deps
+        run: go get ./trealla
+      - name: Build
+        run: go build ./trealla
+      - name: Test
+        run: go test -v ./trealla --short

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/trealla-prolog/go
 
-go 1.19
+go 1.23
 
 require github.com/tetratelabs/wazero v1.7.3

--- a/trealla/example_test.go
+++ b/trealla/example_test.go
@@ -130,7 +130,7 @@ func Example_register_nondet() {
 			// Check Min and Max argument's type, must be integers (all integers are int64).
 			min, ok := goal.Args[0].(int64)
 			if !ok {
-				// throw(error(type_error(list, X), base32/2)).
+				// throw(error(type_error(integer, Min), betwixt/3)).
 				yield(trealla.Atom("throw").Of(trealla.Atom("error").Of(
 					trealla.Atom("type_error").Of("integer", goal.Args[0]),
 					pi,
@@ -141,9 +141,9 @@ func Example_register_nondet() {
 			}
 			max, ok := goal.Args[1].(int64)
 			if !ok {
-				// throw(error(type_error(list, X), base32/2)).
+				// throw(error(type_error(integer, Max), betwixt/3)).
 				yield(trealla.Atom("throw").Of(trealla.Atom("error").Of(
-					trealla.Atom("type_error").Of("integer", goal.Args[0]),
+					trealla.Atom("type_error").Of("integer", goal.Args[1]),
 					pi,
 				)))
 				return

--- a/trealla/example_test.go
+++ b/trealla/example_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base32"
 	"fmt"
+	"iter"
 
 	"github.com/trealla-prolog/go/trealla"
 )
@@ -88,7 +89,7 @@ func Example_register() {
 			// throw(error(type_error(list, X), base32/2)).
 			// See: terms subpackage for convenience functions to create these errors.
 			return trealla.Atom("throw").Of(trealla.Atom("error").Of(
-				trealla.Atom("type_error").Of("list", goal.Args[0]),
+				trealla.Atom("type_error").Of("chars", goal.Args[0]),
 				trealla.Atom("/").Of(trealla.Atom("base32"), 2),
 			))
 		}
@@ -108,4 +109,80 @@ func Example_register() {
 	}
 	fmt.Println(answer.Solution["Encoded"])
 	// Output: NBSWY3DP
+}
+
+func Example_register_nondet() {
+	ctx := context.Background()
+	pl, err := trealla.New()
+	if err != nil {
+		panic(err)
+	}
+
+	// Let's add a native equivalent of between/3.
+	// betwixt(+Min, +Max, ?N).
+	pl.RegisterNondet(ctx, "betwixt", 3, func(_ trealla.Prolog, _ trealla.Subquery, goal0 trealla.Term) iter.Seq[trealla.Term] {
+		pi := trealla.Atom("/").Of(trealla.Atom("betwixt"), 2)
+		return func(yield func(trealla.Term) bool) {
+			// goal is the goal called by Prolog, such as: base32("hello", X).
+			// Guaranteed to match up with the registered arity and name.
+			goal := goal0.(trealla.Compound)
+
+			// Check Min and Max argument's type, must be integers (all integers are int64).
+			min, ok := goal.Args[0].(int64)
+			if !ok {
+				// throw(error(type_error(list, X), base32/2)).
+				yield(trealla.Atom("throw").Of(trealla.Atom("error").Of(
+					trealla.Atom("type_error").Of("integer", goal.Args[0]),
+					pi,
+				)))
+				// See terms subpackage for an easier way:
+				// yield(terms.Throw(terms.TypeError("integer", goal.Args[0], terms.PI(goal)))
+				return
+			}
+			max, ok := goal.Args[1].(int64)
+			if !ok {
+				// throw(error(type_error(list, X), base32/2)).
+				yield(trealla.Atom("throw").Of(trealla.Atom("error").Of(
+					trealla.Atom("type_error").Of("integer", goal.Args[0]),
+					pi,
+				)))
+				return
+			}
+
+			if min > max {
+				// Since we haven't yielded anything, this will fail.
+				return
+			}
+
+			switch x := goal.Args[2].(type) {
+			case int64:
+				// If the 3rd argument is bound, we can do a simple check and stop iterating.
+				if x >= min && x <= max {
+					yield(goal)
+					return
+				}
+			case trealla.Variable:
+				// Create choice points unifying N from min to max
+				for n := min; n <= max; n++ {
+					goal.Args[2] = n
+					if !yield(goal) {
+						break
+					}
+				}
+			default:
+				yield(trealla.Atom("throw").Of(trealla.Atom("error").Of(
+					trealla.Atom("type_error").Of("integer", goal.Args[2]),
+					trealla.Atom("/").Of(trealla.Atom("base32"), 2),
+				)))
+			}
+		}
+	})
+
+	// Try it out.
+	answer, err := pl.QueryOnce(ctx, `findall(N, betwixt(1, 5, N), Ns), write(Ns).`)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(answer.Stdout)
+	// Output: [1,2,3,4,5]
 }

--- a/trealla/interop.go
+++ b/trealla/interop.go
@@ -90,14 +90,14 @@ func sys_coro_next_2(pl Prolog, subquery Subquery, goal Term) Term {
 	if !ok {
 		return throwTerm(domainError("integer", g.Args[0], g.pi()))
 	}
-	t, ok := plc.CoroNext(subquery, id)
-	if !ok || t == nil {
+	result, ok := plc.CoroNext(subquery, id)
+	if !ok || result == nil {
 		return Atom("fail")
 	}
-	// call(( Goal = Result ; '$coro_next'(ID, Goal) ))
+	// call(( wasm_generic:host_rpc_eval(Goal, Result, [], []) ; '$coro_next'(ID, Goal) ))
 	return Atom("call").Of(
 		Atom(";").Of(
-			Atom("=").Of(g.Args[1], t),
+			Atom(":").Of(Atom("wasm_generic"), Atom("host_rpc_eval").Of(result, g.Args[1], Atom("[]"), Atom("[]"))),
 			Atom("$coro_next").Of(id, g.Args[1]),
 		),
 	)

--- a/trealla/interop.go
+++ b/trealla/interop.go
@@ -3,6 +3,8 @@ package trealla
 import (
 	"context"
 	"fmt"
+	"io"
+	"iter"
 )
 
 // Predicate is a Prolog predicate implemented in Go.
@@ -17,9 +19,157 @@ import (
 //   - Return a 'true' atom to succeed without unifying anything.
 type Predicate func(pl Prolog, subquery Subquery, goal Term) Term
 
+// NondetPredicate works similarly to [Predicate], but can create multiple choice points.
+type NondetPredicate func(pl Prolog, subquery Subquery, goal Term) iter.Seq[Term]
+
 // Subquery is an opaque value representing an in-flight query.
 // It is unique as long as the query is alive, but may be re-used later on.
 type Subquery uint32
+
+type coroutine struct {
+	next func() (Term, bool)
+	stop func()
+}
+
+type coroer interface {
+	CoroStart(subq Subquery, seq iter.Seq[Term]) int64
+	CoroNext(subq Subquery, id int64) (Term, bool)
+	CoroStop(subq Subquery, id int64)
+}
+
+func (pl *prolog) Register(ctx context.Context, name string, arity int, proc Predicate) error {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	if pl.instance == nil {
+		return io.EOF
+	}
+	return pl.register(ctx, name, arity, proc)
+}
+
+func (pl *prolog) register(ctx context.Context, name string, arity int, proc Predicate) error {
+	functor := Atom(name)
+	pi := piTerm(functor, arity)
+	pl.procs[pi.String()] = proc
+	vars := numbervars(arity)
+	head := functor.Of(vars...)
+	body := Atom("host_rpc").Of(head)
+	clause := fmt.Sprintf(`%s :- %s.`, head.String(), body.String())
+	return pl.consultText(ctx, "user", clause)
+}
+
+func (pl *prolog) RegisterNondet(ctx context.Context, name string, arity int, proc NondetPredicate) error {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	if pl.instance == nil {
+		return io.EOF
+	}
+	return pl.registerNondet(ctx, name, arity, proc)
+}
+
+func (pl *prolog) registerNondet(ctx context.Context, name string, arity int, proc NondetPredicate) error {
+	shim := func(pl2 Prolog, subquery Subquery, goal Term) Term {
+		plc := pl2.(coroer)
+		seq := proc(pl2, subquery, goal)
+		id := plc.CoroStart(subquery, seq)
+		// call: call_cleanup('$coro_next'(ID), '$coro_stop'(ID))
+		return Atom("call").Of(
+			Atom("call_cleanup").Of(
+				Atom("$coro_next").Of(id, goal),
+				Atom("$coro_stop").Of(id),
+			),
+		)
+	}
+	return pl.register(ctx, name, arity, shim)
+}
+
+// '$coro_next'(+ID, ?Goal)
+func sys_coro_next_2(pl Prolog, subquery Subquery, goal Term) Term {
+	plc := pl.(coroer)
+	g := goal.(Compound)
+	id, ok := g.Args[0].(int64)
+	if !ok {
+		return throwTerm(domainError("integer", g.Args[0], g.pi()))
+	}
+	t, ok := plc.CoroNext(subquery, id)
+	if !ok || t == nil {
+		return Atom("fail")
+	}
+	// call(( Goal = Result ; '$coro_next'(ID, Goal) ))
+	return Atom("call").Of(
+		Atom(";").Of(
+			Atom("=").Of(g.Args[1], t),
+			Atom("$coro_next").Of(id, g.Args[1]),
+		),
+	)
+}
+
+// '$coro_stop'(+ID)
+func sys_coro_stop_1(pl Prolog, subquery Subquery, goal Term) Term {
+	plc := pl.(coroer)
+	g := goal.(Compound)
+	id, ok := g.Args[0].(int64)
+	if !ok {
+		return throwTerm(domainError("integer", g.Args[0], g.pi()))
+	}
+	plc.CoroStop(subquery, id)
+	return goal
+}
+
+func (pl *prolog) CoroStart(subq Subquery, seq iter.Seq[Term]) int64 {
+	pl.coron++
+	id := pl.coron
+	next, stop := iter.Pull(seq)
+	pl.coros[id] = coroutine{
+		next: next,
+		stop: stop,
+	}
+	if query := pl.subquery(uint32(subq)); query != nil {
+		if query.coros == nil {
+			query.coros = make(map[int64]struct{})
+		}
+		query.coros[id] = struct{}{}
+	}
+	return id
+}
+
+func (pl *prolog) CoroNext(subq Subquery, id int64) (Term, bool) {
+	coro, ok := pl.coros[id]
+	if !ok {
+		return Atom("false"), false
+	}
+	next, ok := coro.next()
+	if !ok {
+		delete(pl.coros, id)
+		if query := pl.subquery(uint32(subq)); query != nil {
+			delete(query.coros, id)
+		}
+	}
+	return next, ok
+}
+
+func (pl *prolog) CoroStop(subq Subquery, id int64) {
+	if query := pl.subquery(uint32(subq)); query != nil {
+		delete(query.coros, id)
+	}
+	coro, ok := pl.coros[id]
+	if !ok {
+		return
+	}
+	coro.stop()
+	delete(pl.coros, id)
+}
+
+func (pl *lockedProlog) CoroStart(subq Subquery, seq iter.Seq[Term]) int64 {
+	return pl.prolog.CoroStart(subq, seq)
+}
+
+func (pl *lockedProlog) CoroNext(subq Subquery, id int64) (Term, bool) {
+	return pl.prolog.CoroNext(subq, id)
+}
+
+func (pl *lockedProlog) CoroStop(subq Subquery, id int64) {
+	pl.prolog.CoroStop(subq, id)
+}
 
 func hostCall(ctx context.Context, subquery, msgptr, msgsize, reply_pp, replysize_p uint32) uint32 {
 	// extern int32_t host_call(int32_t subquery, const char *msg, size_t msg_size, char **reply, size_t *reply_size);
@@ -79,7 +229,7 @@ func hostCall(ctx context.Context, subquery, msgptr, msgsize, reply_pp, replysiz
 	// log.Println("SAVING", subq.stderr.String())
 
 	locked := &lockedProlog{prolog: pl}
-	continuation := proc(locked, Subquery(subquery), goal)
+	continuation := catch(proc, locked, Subquery(subquery), goal)
 	locked.kill()
 	expr, err := marshal(continuation)
 	if err != nil {
@@ -92,17 +242,41 @@ func hostCall(ctx context.Context, subquery, msgptr, msgsize, reply_pp, replysiz
 	if err := subq.readOutput(); err != nil {
 		panic(err)
 	}
-	// if _, err := pl.pl_capture.Call(pl.store, pl.ptr); err != nil {
-	// 	return 0, wasmtime.NewTrap(err.Error())
-	// }
-	// if _, err := pl.pl_capture.Call(pl.ctx, uint64(pl.ptr)); err != nil {
-	// 	panic(err)
-	// }
-
 	return wasmTrue
+}
+
+func catch(pred Predicate, pl Prolog, subq Subquery, goal Term) (result Term) {
+	defer func() {
+		if threw := recover(); threw != nil {
+			switch ball := threw.(type) {
+			case Atom:
+				result = throwTerm(ball)
+			case Compound:
+				if ball.Functor == "throw" && len(ball.Args) == 1 {
+					result = ball
+				} else {
+					result = throwTerm(ball)
+				}
+			default:
+				result = throwTerm(
+					Atom("system_error").Of(
+						Atom("panic").Of(fmt.Sprint(threw)),
+						goal.(atomicTerm).pi(),
+					),
+				)
+			}
+		}
+	}()
+	result = pred(pl, subq, goal)
+	return
 }
 
 func hostResume(_, _, _ uint32) uint32 {
 	// extern int32_t host_resume(int32_t subquery, char **reply, size_t *reply_size);
 	return wasmFalse
 }
+
+var (
+	_ coroer = (*prolog)(nil)
+	_ coroer = (*lockedProlog)(nil)
+)

--- a/trealla/interop_test.go
+++ b/trealla/interop_test.go
@@ -207,7 +207,9 @@ func BenchmarkInteropNondet(b *testing.B) {
 			b.Fatal("query failed", query.Err())
 		}
 	}
-	query.Close()
+	if err := query.Close(); err != nil {
+		b.Error("close error:", err)
+	}
 	if leftovers := len(pl.(*prolog).coros); leftovers > 0 {
 		b.Error("coroutines weren't cleaned up:", leftovers)
 	}

--- a/trealla/interop_test.go
+++ b/trealla/interop_test.go
@@ -3,6 +3,7 @@ package trealla
 import (
 	"context"
 	"errors"
+	"iter"
 	"log"
 	"reflect"
 	"testing"
@@ -110,5 +111,104 @@ func TestInterop(t *testing.T) {
 				t.Errorf("bad answer. \nwant: %#v\ngot: %#v\n", tc.want, ans)
 			}
 		})
+	}
+}
+
+func TestInteropNondet(t *testing.T) {
+	pred := func(pl Prolog, subquery Subquery, goal Term) iter.Seq[Term] {
+		return func(yield func(Term) bool) {
+			g := goal.(Compound)
+			n, ok := goal.(Compound).Args[0].(int64)
+			if !ok {
+				yield(throwTerm(typeError("integer", goal.(Compound).Args[0], goal.(atomicTerm).pi())))
+				return
+			}
+			for i := int64(0); i < n; i++ {
+				g.Args[1] = i
+				if !yield(g) {
+					break
+				}
+			}
+		}
+	}
+	ctx := context.Background()
+	pl, err := New(WithDebugLog(log.Default()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pl.RegisterNondet(ctx, "countdown", 2, pred)
+
+	t.Run("success", func(t *testing.T) {
+		q := pl.Query(ctx, "countdown(10, X)")
+		var n int64
+		for answer := range q.All(ctx) {
+			t.Logf("got: %v", answer)
+			if answer.Solution["X"] != n {
+				t.Error("unexpected solution:", answer)
+			}
+			n++
+		}
+		if n != 10 {
+			t.Error("not enough iterations")
+		}
+		if q.Err() != nil {
+			t.Error(q.Err())
+		}
+	})
+
+	t.Run("bad arg", func(t *testing.T) {
+		q := pl.Query(ctx, "countdown(foobar, X)")
+		for q.Next(ctx) {
+		}
+		if q.Err() == nil {
+			t.Error("expected error")
+		}
+	})
+
+	t.Run("abandoned", func(t *testing.T) {
+		q := pl.Query(ctx, "countdown(10, X)")
+		if !q.Next(ctx) {
+			t.Fatal("expected success")
+		}
+		if err := q.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if q.Err() != nil {
+			t.Error(err)
+		}
+	})
+
+	if leftovers := len(pl.(*prolog).coros); leftovers > 0 {
+		t.Error("coroutines weren't cleaned up:", leftovers)
+	}
+}
+
+func BenchmarkInteropNondet(b *testing.B) {
+	pred := func(pl Prolog, subquery Subquery, goal Term) iter.Seq[Term] {
+		return func(yield func(Term) bool) {
+			for i := 0; ; i++ {
+				goal.(Compound).Args[0] = i
+				if !yield(goal) {
+					break
+				}
+			}
+		}
+	}
+	ctx := context.Background()
+	pl, err := New()
+	if err != nil {
+		b.Fatal(err)
+	}
+	pl.RegisterNondet(ctx, "churn", 1, pred)
+	query := pl.Query(ctx, "churn(X).")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !query.Next(ctx) {
+			b.Fatal("query failed", query.Err())
+		}
+	}
+	query.Close()
+	if leftovers := len(pl.(*prolog).coros); leftovers > 0 {
+		b.Error("coroutines weren't cleaned up:", leftovers)
 	}
 }

--- a/trealla/library.go
+++ b/trealla/library.go
@@ -19,14 +19,17 @@ var builtins = []struct {
 	arity int
 	proc  Predicate
 }{
+	{"$coro_next", 2, sys_coro_next_2},
+	{"$coro_stop", 1, sys_coro_stop_1},
 	{"crypto_data_hash", 3, crypto_data_hash_3},
 	{"http_consult", 1, http_consult_1},
 	{"http_fetch", 3, http_fetch_3},
 }
 
 func (pl *prolog) loadBuiltins() error {
+	ctx := context.Background()
 	for _, predicate := range builtins {
-		if err := pl.register(context.Background(), predicate.name, predicate.arity, predicate.proc); err != nil {
+		if err := pl.register(ctx, predicate.name, predicate.arity, predicate.proc); err != nil {
 			return err
 		}
 	}

--- a/trealla/terms/example_test.go
+++ b/trealla/terms/example_test.go
@@ -1,0 +1,75 @@
+package terms_test
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/trealla-prolog/go/trealla"
+	"github.com/trealla-prolog/go/trealla/terms"
+)
+
+func Example_nondet_predicate() {
+	ctx := context.Background()
+	pl, err := trealla.New()
+	if err != nil {
+		panic(err)
+	}
+
+	// Let's add a native equivalent of between/3.
+	// betwixt(+Min, +Max, ?N).
+	pl.RegisterNondet(ctx, "betwixt", 3, func(_ trealla.Prolog, _ trealla.Subquery, goal0 trealla.Term) iter.Seq[trealla.Term] {
+		return func(yield func(trealla.Term) bool) {
+			// goal is the goal called by Prolog, such as: base32("hello", X).
+			// Guaranteed to match up with the registered arity and name.
+			goal := goal0.(trealla.Compound)
+
+			// Check Min and Max argument's type, must be integers (all integers are int64).
+			// TODO: should throw instantiation_error instead of type_error if Min or Max are variables.
+			min, ok := goal.Args[0].(int64)
+			if !ok {
+				// throw(error(type_error(integer, Min), betwixt/3)).
+				yield(terms.Throw(terms.TypeError("integer", goal.Args[0], terms.PI(goal))))
+				return
+			}
+			max, ok := goal.Args[1].(int64)
+			if !ok {
+				// throw(error(type_error(integer, Max), betwixt/3)).
+				yield(terms.Throw(terms.TypeError("integer", goal.Args[1], terms.PI(goal))))
+				return
+			}
+
+			if min > max {
+				// Since we haven't yielded anything, this will fail.
+				return
+			}
+
+			switch x := goal.Args[2].(type) {
+			case int64:
+				// If the 3rd argument is bound, we can do a simple check and stop iterating.
+				if x >= min && x <= max {
+					yield(goal)
+					return
+				}
+			case trealla.Variable:
+				// Create choice points unifying N from min to max
+				for n := min; n <= max; n++ {
+					goal.Args[2] = n
+					if !yield(goal) {
+						break
+					}
+				}
+			default:
+				yield(terms.Throw(terms.TypeError("integer", goal.Args[2], terms.PI(goal))))
+			}
+		}
+	})
+
+	// Try it out.
+	answer, err := pl.QueryOnce(ctx, `findall(N, betwixt(1, 5, N), Ns), write(Ns).`)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(answer.Stdout)
+	// Output: [1,2,3,4,5]
+}

--- a/trealla/terms/example_test.go
+++ b/trealla/terms/example_test.go
@@ -20,7 +20,7 @@ func Example_nondet_predicate() {
 	// betwixt(+Min, +Max, ?N).
 	pl.RegisterNondet(ctx, "betwixt", 3, func(_ trealla.Prolog, _ trealla.Subquery, goal0 trealla.Term) iter.Seq[trealla.Term] {
 		return func(yield func(trealla.Term) bool) {
-			// goal is the goal called by Prolog, such as: base32("hello", X).
+			// goal is the goal called by Prolog, such as: betwixt(1, 10, X).
 			// Guaranteed to match up with the registered arity and name.
 			goal := goal0.(trealla.Compound)
 

--- a/trealla/terms/term.go
+++ b/trealla/terms/term.go
@@ -4,6 +4,7 @@ package terms
 
 import (
 	"math/big"
+	"slices"
 
 	"github.com/trealla-prolog/go/trealla"
 )
@@ -96,4 +97,28 @@ func IsList(x trealla.Term) bool {
 		return x == "[]"
 	}
 	return false
+}
+
+// Substitute returns a copy of the term x with its arguments replaced by args.
+// A nil argument will be kept as-is.
+// If len(args) > 0, x must be [trealla.Compound].
+func Substitute(x trealla.Term, args ...trealla.Term) trealla.Term {
+	if len(args) == 0 {
+		return x
+	}
+	cmp, ok := x.(trealla.Compound)
+	if !ok {
+		pi := PI(x)
+		if pi == nil {
+			pi = trealla.Atom("/").Of(trealla.Atom("go$terms.Substitute"), int64(len(args)))
+		}
+		return Throw(TypeError("compound", x, pi))
+	}
+	goal := trealla.Compound{Functor: cmp.Functor, Args: slices.Clone(cmp.Args)}
+	for i, arg := range args {
+		if arg != nil {
+			goal.Args[i] = arg
+		}
+	}
+	return goal
 }


### PR DESCRIPTION
Adds `Query.All()` which returns an iterator, and a new kind of predicate that can create multiple choice points using iterators.